### PR TITLE
Fix nginx DEB task

### DIFF
--- a/tasks/setup-Debian.yml
+++ b/tasks/setup-Debian.yml
@@ -2,5 +2,5 @@
 - name: Install nginx DEB
   apt:
     name: '{{item}}'
-    state: installed
+    state: present
   with_items: '{{ nginx_deb_packages }}'


### PR DESCRIPTION
With ansible 2.9.4, I've got this error:

```
TASK [VerosK.nginx : Install nginx DEB] ******************************************************************************************************************************************************************************************************
[DEPRECATION WARNING]: Invoking "apt" only once while using a loop via squash_actions is deprecated. Instead of using a loop to supply multiple items and specifying `name: "{{item}}"`, please use `name: '{{ nginx_deb_packages }}'` and
remove the loop. This feature will be removed in version 2.11. Deprecation warnings can be disabled by setting deprecation_warnings=False in ansible.cfg.
failed: [test] (item=[u'nginx']) => {"ansible_loop_var": "item", "changed": false, "item": ["nginx"], "msg": "value of state must be one of: absent, build-dep, fixed, latest, present, got: installed"}
```

According to [documentation](https://docs.ansible.com/ansible/latest/modules/apt_module.html#parameter-state), `installed` is not available choice. This PR changes it to `present`.